### PR TITLE
Improved blank line/comment handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,9 @@ Defaults to `'(environ-ignore-bash-vars)`.
 
 ## File Format
 
-Each non-empty, non-comment line in an env file must be in a `KEY=VALUE` 
-format, with one entry per line. This package invokes a `bash` shell to 
-interpret the file, so shellisms should work (like `~` expansion or using 
+Each non-empty, non-comment line in an env file must be in a `KEY=VALUE`
+format, with one entry per line. This package invokes a `bash` shell to
+interpret the file, so shellisms should work (like `~` expansion or using
 single quotes to prevent variable interpolation).
 
 For example:
@@ -248,9 +248,7 @@ B="bar"
 C='R$%!$KP$'
 D=$A-bar
 E=~/cats
-# F ignored
-
-H=is-not
+# This line is a comment and is ignored
 ```
 
 ## Usage from org-mode

--- a/README.md
+++ b/README.md
@@ -235,10 +235,10 @@ Defaults to `'(environ-ignore-bash-vars)`.
 
 ## File Format
 
-Each line in an env file must be in a `KEY=VALUE` format, with one entry per
-line. This package invokes an `bash` shell to interpret the file, so shellisms
-should work (like `~` expansion or using single quotes to prevent variable
-interpolation).
+Each non-empty, non-comment line in an env file must be in a `KEY=VALUE` 
+format, with one entry per line. This package invokes a `bash` shell to 
+interpret the file, so shellisms should work (like `~` expansion or using 
+single quotes to prevent variable interpolation).
 
 For example:
 
@@ -248,6 +248,9 @@ B="bar"
 C='R$%!$KP$'
 D=$A-bar
 E=~/cats
+# F ignored
+
+H=is-not
 ```
 
 ## Usage from org-mode

--- a/environ.el
+++ b/environ.el
@@ -190,9 +190,13 @@ For example:
 
   (environ-str-to-pairs \"A=a\nB=b\")
   ;;=> ((A a) (B b))"
-  (-> str
+  (->> str
       s-trim
       s-lines
+      (--filter (let ((line (s-trim it)))
+                 (and (not (s-blank? line))
+                      (not (s-starts-with? "#" line))
+                      (s-contains? "=" line))))
       environ-lines-to-pairs))
 
 (defun environ-lines-to-pairs (lines)

--- a/test/environ-test.el
+++ b/test/environ-test.el
@@ -42,7 +42,13 @@ REL-PATH is a path relative to this project's root."
   (let ((process-environment '()))
     (environ-set-str "A=a\nB=b")
     (should (equal "a" (getenv "A")))
-    (should (equal "b" (getenv "B")))))
+    (should (equal "b" (getenv "B"))))
+
+  ;; Lines that start with '#' (comments) are ignored
+  (let ((process-environment '()))
+    (environ-set-str "A=a\nB=b\n#C=c")
+    (should (-same-items? '("A=a" "B=b")
+                          process-environment))))
 
 (ert-deftest environ-unset-str ()
   "Test running `environ-unset-str'."

--- a/test/examples/simple
+++ b/test/examples/simple
@@ -3,3 +3,4 @@ B="bar"
 C='R$%!$KP$'
 D=$A-bar
 E=~/cats
+# This is a comment


### PR DESCRIPTION
# Improved blank line/comment handling

This PR enhances `environ-str-to-pairs`:
- Ignore blank and comment lines in env files to avoid bash `declare -x` noise

The **File Format** documentation example is updated to reflect changes